### PR TITLE
Add 2rem space between profile bio paragraphs

### DIFF
--- a/src/Profile.css
+++ b/src/Profile.css
@@ -93,6 +93,12 @@
   content: "";
 }
 
+.ProfileBioContent {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
 @media (max-width: 599.5px) {
   .Profile {
     margin: 0 0 2rem;


### PR DESCRIPTION
Requested by Marina:

> Is it possible to edit the coach / tutor bio form so that when the bio is laid out on our internal site, it retains the paragraph breaks? (This is where DCRs go to copy the bios to send to clients, and so even though the code now allows for the paragraph breaks to show up in the public link, we don't have them here in our dashboard view.) 
>
> And if it's possible for there to be a slightly larger space between paragraphs (in both the public page and our internal one) that would help with readability and professionalism. Thank you!

The corresponding Dashboard PR is [here](https://github.com/privateprep/dashboard/pull/10382).